### PR TITLE
delete unneccesary gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,7 +71,6 @@ GEM
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.3)
-    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.8)
     crass (1.0.6)
@@ -193,8 +192,6 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     zeitwerk (2.4.2)
 
 PLATFORMS
@@ -206,7 +203,6 @@ DEPENDENCIES
   binding_of_caller
   bootsnap (>= 1.4.4)
   byebug
-  dotenv
   dotenv-rails
   jbuilder (~> 2.7)
   line-bot-api (~> 1.19)
@@ -222,7 +218,6 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 4.1.0)
   webpacker (~> 5.0)
-  whenever
 
 RUBY VERSION
    ruby 3.0.1p64


### PR DESCRIPTION
Herokuデプロイ時に以下エラーが出た為、`docker-compose exec web bundle`を実行しました。


```
remote:  !
remote:  !     Failed to install gems via Bundler.
remote:  !
remote:  !     Push rejected, failed to compile Ruby app.
```